### PR TITLE
Revise branding and signup flow

### DIFF
--- a/invoice-summarizer/app/settings/page.tsx
+++ b/invoice-summarizer/app/settings/page.tsx
@@ -20,14 +20,11 @@ import {
   EnvelopeIcon,
   PhoneIcon,
   CameraIcon,
-  BuildingOfficeIcon,
   BellIcon,
   ShieldCheckIcon,
   TrashIcon,
   ExclamationTriangleIcon,
   Cog6ToothIcon,
-  GlobeAltIcon,
-  MapPinIcon,
   KeyIcon,
   CheckCircleIcon,
 } from "@heroicons/react/24/outline";
@@ -407,7 +404,11 @@ export default function SettingsPage() {
                         name={profile.first_name + " " + profile.last_name}
                         size="lg"
                         src={
-                          profile.avatar_url || getDefaultAvatarUrl(profile.first_name + " " + profile.last_name, profile.email)
+                          profile.avatar_url ||
+                          getDefaultAvatarUrl(
+                            profile.first_name + " " + profile.last_name,
+                            profile.email,
+                          )
                         }
                       />
                       <div className="flex gap-3">
@@ -510,80 +511,6 @@ export default function SettingsPage() {
                     </Button>
                   </div>
                 )}
-              </CardBody>
-            </Card>
-
-            {/* Company Information */}
-            <Card className="bg-content1/50 backdrop-blur-sm border-1 border-divider/50">
-              <CardHeader className="pb-4">
-                <div className="flex items-center gap-3">
-                  <div className="bg-secondary/10 rounded-full p-2">
-                    <BuildingOfficeIcon className="w-5 h-5 text-secondary" />
-                  </div>
-                  <h3 className="text-lg font-semibold">Company Information</h3>
-                </div>
-              </CardHeader>
-              <CardBody className="pt-0">
-                <div className="space-y-6">
-                  <div className="flex items-center gap-6">
-                    <div className="bg-secondary/20 rounded-lg p-4 w-16 h-16 flex items-center justify-center">
-                      <BuildingOfficeIcon className="w-8 h-8 text-secondary" />
-                    </div>
-                    <div className="flex gap-3">
-                      <Button
-                        color="secondary"
-                        size="sm"
-                        startContent={<CameraIcon className="w-4 h-4" />}
-                        variant="bordered"
-                      >
-                        Upload Logo
-                      </Button>
-                      <Button color="danger" size="sm" variant="light">
-                        Remove
-                      </Button>
-                    </div>
-                  </div>
-
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <Input
-                      defaultValue="AI Invoice Summarizer"
-                      label="Company Name"
-                      placeholder="Your Company Name"
-                      startContent={
-                        <BuildingOfficeIcon className="w-4 h-4 text-default-400" />
-                      }
-                      variant="bordered"
-                    />
-                    <Input
-                      defaultValue="https://invoice-summarizer.com"
-                      label="Website"
-                      placeholder="https://example.com"
-                      startContent={
-                        <GlobeAltIcon className="w-4 h-4 text-default-400" />
-                      }
-                      variant="bordered"
-                    />
-                  </div>
-
-                  <textarea
-                    className="border rounded-lg p-2 w-full min-h-[80px]"
-                    placeholder="Brief description of your company"
-                    value={profile?.tagline || ""}
-                    onChange={(e) =>
-                      handleProfileChange("tagline", e.target.value)
-                    }
-                  />
-
-                  <Input
-                    defaultValue="123 Business St, City, State 12345"
-                    label="Address"
-                    placeholder="Enter your business address"
-                    startContent={
-                      <MapPinIcon className="w-4 h-4 text-default-400" />
-                    }
-                    variant="bordered"
-                  />
-                </div>
               </CardBody>
             </Card>
 

--- a/invoice-summarizer/app/signup/page.tsx
+++ b/invoice-summarizer/app/signup/page.tsx
@@ -95,22 +95,13 @@ export default function SignupPage() {
                   Click the link in your email to verify your account and start
                   using AI Invoice Summarizer.
                 </p>
-                <div className="bg-warning/10 border border-warning/20 rounded-lg p-4">
-                  <p className="text-sm text-warning">
-                    <strong>Can&apos;t find the email?</strong> Check your spam
-                    folder or try signing up again.
-                  </p>
-                </div>
                 <Button
-                  variant="bordered"
+                  color="primary"
                   onPress={() => {
-                    setShowVerificationMessage(false);
-                    setEmail("");
-                    setPassword("");
-                    setConfirmPassword("");
+                    router.push("/login");
                   }}
                 >
-                  Try Again
+                  Go to Login
                 </Button>
               </div>
             </CardBody>

--- a/invoice-summarizer/components/dashboard-layout.tsx
+++ b/invoice-summarizer/components/dashboard-layout.tsx
@@ -113,7 +113,12 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
         />
         <div className="fixed inset-y-0 left-0 w-64 bg-content1 border-r border-divider">
           <div className="flex items-center justify-between p-4 border-b border-divider">
-            <h2 className="text-lg font-semibold">AI Invoice Summarizer</h2>
+            <h2 className="text-lg font-semibold leading-tight">
+              AI Invoice Summarizer
+              <span className="block text-xs font-normal text-default-500">
+                By Nexorus
+              </span>
+            </h2>
             <Button
               isIconOnly
               variant="light"
@@ -141,7 +146,12 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
       <div className="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-64 lg:flex-col">
         <div className="flex grow flex-col gap-y-5 overflow-y-auto bg-content1 border-r border-divider px-6">
           <div className="flex h-16 shrink-0 items-center">
-            <h2 className="text-lg font-semibold">AI Invoice Summarizer</h2>
+            <h2 className="text-lg font-semibold leading-tight">
+              AI Invoice Summarizer
+              <span className="block text-xs font-normal text-default-500">
+                By Nexorus
+              </span>
+            </h2>
           </div>
           <nav className="flex flex-1 flex-col">
             <ul className="flex flex-1 flex-col gap-y-7">

--- a/invoice-summarizer/components/navbar.tsx
+++ b/invoice-summarizer/components/navbar.tsx
@@ -26,7 +26,6 @@ import {
   DiscordIcon,
   HeartFilledIcon,
   SearchIcon,
-  Logo,
 } from "@/components/icons";
 
 export const Navbar = () => {
@@ -65,9 +64,11 @@ export const Navbar = () => {
     <HeroUINavbar maxWidth="xl" position="sticky">
       <NavbarContent className="basis-1/5 sm:basis-full" justify="start">
         <NavbarBrand as="li" className="gap-3 max-w-fit">
-          <NextLink className="flex justify-start items-center gap-1" href="/">
-            <Logo />
-            <p className="font-bold text-inherit">ACME</p>
+          <NextLink className="flex flex-col justify-start" href="/">
+            <span className="font-bold text-inherit leading-none">
+              AI Invoice Summarizer
+            </span>
+            <span className="text-xs text-default-500">By Nexorus</span>
           </NextLink>
         </NavbarBrand>
         <ul className="hidden lg:flex gap-4 justify-start ml-2">


### PR DESCRIPTION
## Summary
- Replace ACME branding with "AI Invoice Summarizer" and "By Nexorus" tagline
- Show login button after signup email verification
- Remove unused company information section from settings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a22908dd6083318a43a1a6a56a3e2d